### PR TITLE
Add a card with community calendar information

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -23,3 +23,7 @@
   des: As a community project, we welcome contributions! The package is developed and used by the community.
   buttonname: Contribute
   link: https://tvm.apache.org/docs/contribute/
+- cardname: Calendar
+  des: The TVM Community conducts a number of public events, including monthly general meetings, project sub-meetings, and the annual TVM Conference. You can subscribe to the public events calendar here.
+  buttomname: Calendar
+  link: https://calendar.google.com/calendar/embed?src=071aaettatchrj779v0k8jsmcc%40group.calendar.google.com


### PR DESCRIPTION
Now that the community calendar is open for members of the
community to post events to, add a new card with a permanent
link to the calendar for discoverability.