### PR TITLE
Update README with instructions on getting depdencies and serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ website.tgz
 .jekyll-cache
 docs.tgz
 Gemfile.lock
+.bundle/
+vendor/
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,42 @@
 # TVM Project Homepage
 
-## Prereq
+## Dependencies
 
-- Install the jekyll and bundler gems `gem install bundler jekyll`
+1. Install Ruby
 
+    ```bash
+    # for Ubuntu 18.04+
+    sudo apt install -y ruby-full build-essential
+    ```
+
+2. Install Jekyll and Bundler gems
+
+    ```bash
+    gem install bundler jekyll
+    ```
+
+3. Install project dependencies
+
+    ```bash
+    git clone https://github.com/apache/tvm-site.git
+    cd tvm-site
+
+    # If this runs into resolution errors, you may need to run:
+    # bundle config set --local path 'vendor/cache'
+    bundle install
+    ```
 
 ## Serve Locally
 
 ```bash
 ./serve_local.sh
+
+# If you are developing on a remote machine, you can set up an SSH tunnel to view
+# the site locally:
+ssh -L 4000:localhost:4000 <the remote>
 ```
+
+Then visit [http://localhost:4000](http://localhost:4000) in your browser.
 
 ## Deployment
 

--- a/serve_local.sh
+++ b/serve_local.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm -rf _site
-jekyll serve --watch
+bundle exec jekyll serve --watch


### PR DESCRIPTION
This are the commands I had to run to get the docs building from scratch on an Ubuntu machine. On MacOS as far as I can tell the pre-installed ruby is fine so just the `gem install` + `bundle exec` are needed
