### PR TITLE
[Docs] Updated the copyright year from 2020 to 2023

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,7 +38,7 @@
         <p><a href="/"><img src="/assets/images/logo.svg" alt="logo" title="logo" /></a></p>
       </li>
       <li class="copywrite d-flex align-items-center">
-        <h5 id="apache-software-foundation--all-right-reserved">© 2020 Apache Software Foundation | All right reserved</h5>
+        <h5 id="apache-software-foundation--all-right-reserved">© 2023 Apache Software Foundation | All right reserved</h5>
       </li>
     </ul>
 
@@ -46,7 +46,7 @@
 
   <ul class="container">
     <li class="footernote">
-      Copyright © 2020 The Apache Software Foundation. Apache TVM, Apache, the Apache feather, and the Apache TVM project logo are either trademarks or registered trademarks of the Apache Software Foundation.</li>
+      Copyright © 2023 The Apache Software Foundation. Apache TVM, Apache, the Apache feather, and the Apache TVM project logo are either trademarks or registered trademarks of the Apache Software Foundation.</li>
   </ul>
 
 </section>


### PR DESCRIPTION
Hi @vinx13 @areusch 

This is a minor PR and it aims to update the copyright year from 2020 to 2023. I would appreciate that if you can help to review/manage it, thanks.

Reference: https://github.com/apache/tvm/pull/15071
Reference: https://github.com/apache/tvm/issues/15043