### PR TITLE
Make the project-specific security page more prominent

### DIFF
--- a/_data/submenu.yml
+++ b/_data/submenu.yml
@@ -5,7 +5,7 @@
 - sub: Sponsorship
   sublink: https://www.apache.org/foundation/sponsorship.html
 - sub: Security
-  sublink: https://www.apache.org/security/
+  sublink: https://tvm.apache.org/docs/reference/security.html
 - sub: Thanks
   sublink: https://www.apache.org/foundation/thanks.html
 - sub: Events

--- a/asf.md
+++ b/asf.md
@@ -16,7 +16,7 @@ description: "ASF"
 <a href="https://www.apache.org/foundation/sponsorship.html" class="link-btn">Sponsorship</a>
 
 
-<a href="https://www.apache.org/security/" class="link-btn">Security</a>
+<a href="https://tvm.apache.org/docs/reference/security.html" class="link-btn">Security</a>
 
 <a href="https://www.apache.org/foundation/thanks.html" class="link-btn">Thanks</a>
 


### PR DESCRIPTION
We want people to read that page first. When they want to see the ASF-wide security policies they can find those via the project-specific page.