### PR TITLE
[CI] Update setup-uv ref for TVM-FFI docs publish

### DIFF
--- a/.github/workflows/publish_tvm_ffi_docs.yml
+++ b/.github/workflows/publish_tvm_ffi_docs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python 3.13
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7.3.1
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: 3.13
           activate-environment: true


### PR DESCRIPTION
## Summary

ASF infrastructure-actions no longer allows the previous setup-uv v7.3.1 pin used by the TVM-FFI docs publish workflow. This updates the workflow to the allowed durable v8.2.0 ref.

- Update `astral-sh/setup-uv` from `5a095e7a2014a4212f075830d4f7277575a9d098` to `fac544c07dec837d0ccb6301d7b5580bf5edae39`.
- Keep the existing setup-uv inputs unchanged.