### PR TITLE
Blog: add pip install command under the wheel link

### DIFF
--- a/_posts/2026-06-22-tirx.md
+++ b/_posts/2026-06-22-tirx.md
@@ -31,6 +31,11 @@ You can find the following resources:
 - GitHub: [https://github.com/apache/tvm](https://github.com/apache/tvm)
 - Documentation: [https://tvm.apache.org/docs/tirx/overview.html](https://tvm.apache.org/docs/tirx/overview.html)
 - PyPI wheel: [https://pypi.org/project/apache-tvm/0.25.0/](https://pypi.org/project/apache-tvm/0.25.0/)
+
+  ```bash
+  pip install apache-tvm==0.25.0
+  ```
+
 - Community TIRx kernel library: [https://github.com/mlc-ai/tirx-kernels](https://github.com/mlc-ai/tirx-kernels)
 - Modern GPU programming for machine learning systems: [https://mlc.ai/modern-gpu-programming-for-mlsys/index.html](https://mlc.ai/modern-gpu-programming-for-mlsys/index.html)
 


### PR DESCRIPTION
Adds a copy-pasteable `pip install apache-tvm==0.25.0` snippet under the PyPI wheel link in the resources list.