### PR TITLE
Render blog math with MathJax 3 (SVG), self-hosted under the site CSP

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,8 @@
       <meta property="og:image" content="{{ page.preview_image }}">
     {% endif %}
     {% if page.mathjax %}
-      <script>(function () { var s = document.createElement('script'); s.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_CHTML'; document.head.appendChild(s); })();</script>
+      <script>window.MathJax = { tex: { inlineMath: [['$', '$'], ['\\(', '\\)']], displayMath: [['$$', '$$'], ['\\[', '\\]']] } };</script>
+      <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
     {% endif %}
 </head>
 <body>


### PR DESCRIPTION
The post's formulas rendered as raw LaTeX: the site CSP (script-src 'self') blocks the cdnjs MathJax, and the v2 `?config=` URL also can't be self-hosted by the embed localizer (it rejects query strings). Switch to MathJax 3 `tex-svg.js` from a no-query jsdelivr URL, which the localizer downloads and serves from 'self' (so the CSP allows it). SVG output is self-contained (no external font files). Config enables $$…$$ and \[…\] delimiters.