### PR TITLE
Edit TIRx post: acknowledgements and contributing wording

### DIFF
--- a/_posts/2026-06-22-tirx.md
+++ b/_posts/2026-06-22-tirx.md
@@ -294,8 +294,8 @@ In this view, TIRx is not just a target language for generated kernels. It is so
 
 ## **Contributing**
 
-TIRx is an open compiler foundation. The core abstraction boundary is intentionally small, but the ecosystem around it can grow in several directions. Feel free to try out TIRx and contribute to the compiler and kernel library!
+TIRx is an open compiler foundation. The core abstraction boundary is intentionally small, but the ecosystem around it can grow in several directions. Feel free to try out TIRx and contribute to the compiler and the community projects.
 
 ## **Acknowledgement**
 
-TIRx would not exist without Apache TVM, on whose compiler infrastructure it is built. Beyond that foundation, its design has been shaped by a long line of systems work, including NumPy, CuTe, Triton, ThunderKittens, and TileLang. We thank the FlashInfer and FlashInfer-Bench teams and the Apache TVM community for helpful technical discussions.
+TIRx would not exist without Apache TVM, on whose compiler infrastructure it is built. Beyond that foundation, its design has been shaped by a long line of systems work, including NumPy, CuTe, Triton, ThunderKittens, and TileLang. We thank the FlashInfer, FlashInfer-Bench, and TileLang teams and the Apache TVM community for helpful technical discussions.


### PR DESCRIPTION
Two small copy edits to the 2026-06-22 TIRx post:

- **Acknowledgements:** add the TileLang team alongside the FlashInfer and FlashInfer-Bench teams for helpful technical discussions.
- **Contributing:** invite contributions to the compiler and the community projects (generic) rather than naming the kernel library specifically.