### PR TITLE
Update pip install command for apache-tvm for TIRx post

### DIFF
--- a/_posts/2026-06-22-tirx.md
+++ b/_posts/2026-06-22-tirx.md
@@ -33,7 +33,7 @@ You can find the following resources:
 - PyPI wheel: [https://pypi.org/project/apache-tvm/0.25.0/](https://pypi.org/project/apache-tvm/0.25.0/)
 
   ```bash
-  pip install apache-tvm==0.25.0
+  pip install apache-tvm
   ```
 
 - Community TIRx kernel library: [https://github.com/mlc-ai/tirx-kernels](https://github.com/mlc-ai/tirx-kernels)


### PR DESCRIPTION
Updated installation command for apache-tvm to the latest version.